### PR TITLE
feat(analysis): add PatternSignal and PatternMetric;
emit detection metrics

### DIFF
--- a/src/integration/java/com/blockchain/blockpulseservice/controller/AnalysisControllerIT.java
+++ b/src/integration/java/com/blockchain/blockpulseservice/controller/AnalysisControllerIT.java
@@ -1,7 +1,9 @@
 package com.blockchain.blockpulseservice.controller;
 
-import com.blockchain.blockpulseservice.model.domain.PatternType;
 import com.blockchain.blockpulseservice.model.domain.PriceTier;
+import com.blockchain.blockpulseservice.model.domain.PatternSignal;
+import com.blockchain.blockpulseservice.model.domain.PatternMetric;
+import com.blockchain.blockpulseservice.model.domain.PatternType;
 import com.blockchain.blockpulseservice.model.dto.TransactionWindowSnapshotDTO;
 import com.blockchain.blockpulseservice.model.event.AnalyzedTransactionEvent;
 import com.blockchain.blockpulseservice.service.stream.AnalysisStream;
@@ -17,8 +19,8 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
+import java.util.Map;
 import java.time.Instant;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -44,7 +46,7 @@ class AnalysisControllerIT {
                 .totalFee(new BigDecimal("1550"))
                 .txSize(100)
                 .timestamp(Instant.now())
-                .patternTypes(Set.of(PatternType.SURGE))
+                .patternSignal(new PatternSignal(PatternType.SURGE, Map.of(PatternMetric.UPPER_TUKEY_FENCE, 30.0)))
                 .priceTier(PriceTier.NORMAL)
                 .isOutlier(false)
                 .windowSnapshot(new TransactionWindowSnapshotDTO(10, 0, BigDecimal.ZERO, BigDecimal.ZERO))

--- a/src/integration/java/com/blockchain/blockpulseservice/e2e/GetAnalyzedTransactionEventsIT.java
+++ b/src/integration/java/com/blockchain/blockpulseservice/e2e/GetAnalyzedTransactionEventsIT.java
@@ -134,7 +134,7 @@ class GetAnalyzedTransactionEventsIT extends BaseIT {
                     assertThat(tx.totalFee()).isEqualByComparingTo("2000");
                     assertThat(tx.txSize()).isEqualTo(200);
                     assertThat(tx.timestamp()).isEqualTo(Instant.parse("1970-01-01T00:00:10Z"));
-                    assertThat(tx.patternTypes()).isEmpty();
+                    assertThat(tx.patternSignal()).isNull();
                     assertThat(tx.priceTier()).isEqualTo(PriceTier.EXPENSIVE);
                     assertThat(tx.isOutlier()).isFalse();
                 })

--- a/src/main/java/com/blockchain/blockpulseservice/config/analysis/AnalysisChainConfig.java
+++ b/src/main/java/com/blockchain/blockpulseservice/config/analysis/AnalysisChainConfig.java
@@ -3,7 +3,7 @@ package com.blockchain.blockpulseservice.config.analysis;
 import com.blockchain.blockpulseservice.service.analysis.price_tier.PriceTierAnalyzer;
 import com.blockchain.blockpulseservice.service.analysis.OutlierFeeAnalyzer;
 import com.blockchain.blockpulseservice.service.analysis.SurgeFeeAnalyzer;
-import com.blockchain.blockpulseservice.service.analysis.SpamFeeAnalyzer;
+import com.blockchain.blockpulseservice.service.analysis.ScamFeeAnalyzer;
 import com.blockchain.blockpulseservice.service.analysis.FeeAnalyzer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,11 +13,11 @@ public class AnalysisChainConfig {
 
     @Bean
     public FeeAnalyzer analysisChain(OutlierFeeAnalyzer outlierAnalyzer,
-                                     SpamFeeAnalyzer spamFeeAnalyzer,
+                                     ScamFeeAnalyzer scamFeeAnalyzer,
                                      SurgeFeeAnalyzer surgeFeeAnalyzer,
                                      PriceTierAnalyzer priceTierAnalyzer) {
         outlierAnalyzer
-                .setNext(spamFeeAnalyzer)
+                .setNext(scamFeeAnalyzer)
                 .setNext(surgeFeeAnalyzer)
                 .setNext(priceTierAnalyzer);
 

--- a/src/main/java/com/blockchain/blockpulseservice/model/domain/AnalysisContext.java
+++ b/src/main/java/com/blockchain/blockpulseservice/model/domain/AnalysisContext.java
@@ -1,10 +1,9 @@
 package com.blockchain.blockpulseservice.model.domain;
 
 import lombok.Builder;
-import lombok.Singular;
 import lombok.Value;
 
-import java.util.Set;
+ 
 
 @Value
 @Builder(toBuilder = true)
@@ -13,8 +12,7 @@ public class AnalysisContext {
     Transaction newTransaction;
     FeeWindowStatsSummary feeWindowStatsSummary;
     // output
-    @Singular("pattern")
-    Set<PatternType> patterns;
+    PatternSignal patternSignal;
     PriceTier priceTier;
     @Builder.Default
     boolean isOutlier = false;

--- a/src/main/java/com/blockchain/blockpulseservice/model/domain/PatternMetric.java
+++ b/src/main/java/com/blockchain/blockpulseservice/model/domain/PatternMetric.java
@@ -1,0 +1,9 @@
+package com.blockchain.blockpulseservice.model.domain;
+
+public enum PatternMetric {
+    UPPER_TUKEY_FENCE,
+    LOWER_TUKEY_FENCE,
+    MEMPOOL_SIZE,
+    MEMPOOL_RECOMMENDED_FEE_PER_VBYTE,
+}
+

--- a/src/main/java/com/blockchain/blockpulseservice/model/domain/PatternSignal.java
+++ b/src/main/java/com/blockchain/blockpulseservice/model/domain/PatternSignal.java
@@ -1,0 +1,5 @@
+package com.blockchain.blockpulseservice.model.domain;
+
+import java.util.Map;
+
+public record PatternSignal(PatternType type, Map<PatternMetric, Double> metrics) {}

--- a/src/main/java/com/blockchain/blockpulseservice/model/event/AnalyzedTransactionEvent.java
+++ b/src/main/java/com/blockchain/blockpulseservice/model/event/AnalyzedTransactionEvent.java
@@ -1,13 +1,12 @@
 package com.blockchain.blockpulseservice.model.event;
 
 import com.blockchain.blockpulseservice.model.domain.PriceTier;
-import com.blockchain.blockpulseservice.model.domain.PatternType;
+import com.blockchain.blockpulseservice.model.domain.PatternSignal;
 import com.blockchain.blockpulseservice.model.dto.TransactionWindowSnapshotDTO;
 import lombok.Builder;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.Set;
 
 @Builder
 public record AnalyzedTransactionEvent(String id,
@@ -16,7 +15,7 @@ public record AnalyzedTransactionEvent(String id,
                                        BigDecimal totalFee,
                                        int txSize,
                                        Instant timestamp,
-                                       Set<PatternType> patternTypes,
+                                       PatternSignal patternSignal,
                                        PriceTier priceTier,
                                        boolean isOutlier,
                                        TransactionWindowSnapshotDTO windowSnapshot) {}

--- a/src/main/java/com/blockchain/blockpulseservice/service/analysis/ScamFeeAnalyzer.java
+++ b/src/main/java/com/blockchain/blockpulseservice/service/analysis/ScamFeeAnalyzer.java
@@ -2,10 +2,13 @@ package com.blockchain.blockpulseservice.service.analysis;
 
 import com.blockchain.blockpulseservice.model.domain.AnalysisContext;
 import com.blockchain.blockpulseservice.model.domain.PatternType;
+import com.blockchain.blockpulseservice.model.domain.PatternSignal;
+import com.blockchain.blockpulseservice.model.domain.PatternMetric;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
-public class SpamFeeAnalyzer extends BaseFeeAnalyzer {
+public class ScamFeeAnalyzer extends BaseFeeAnalyzer {
     @Override
     protected AnalysisContext doAnalyze(AnalysisContext context) {
         var fee = context.getNewTransaction().feePerVSize();
@@ -13,7 +16,10 @@ public class SpamFeeAnalyzer extends BaseFeeAnalyzer {
 
         if (fee.compareTo(lowerFence) < 0) {
             return context.toBuilder()
-                    .pattern(PatternType.SCAM)
+                    .patternSignal(new PatternSignal(
+                            PatternType.SCAM,
+                            Map.of(PatternMetric.LOWER_TUKEY_FENCE, lowerFence.doubleValue())
+                    ))
                     .build();
         }
 

--- a/src/main/java/com/blockchain/blockpulseservice/service/analysis/SurgeFeeAnalyzer.java
+++ b/src/main/java/com/blockchain/blockpulseservice/service/analysis/SurgeFeeAnalyzer.java
@@ -3,11 +3,14 @@ package com.blockchain.blockpulseservice.service.analysis;
 import com.blockchain.blockpulseservice.model.domain.AnalysisContext;
 import com.blockchain.blockpulseservice.model.domain.MempoolStats;
 import com.blockchain.blockpulseservice.model.domain.PatternType;
+import com.blockchain.blockpulseservice.model.domain.PatternSignal;
+import com.blockchain.blockpulseservice.model.domain.PatternMetric;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -29,7 +32,14 @@ public class SurgeFeeAnalyzer extends BaseFeeAnalyzer {
         if (isSurge) {
             log.debug("Surge detected for tx: {}", context.getNewTransaction().id());
             return context.toBuilder()
-                    .pattern(PatternType.SURGE)
+                    .patternSignal(new PatternSignal(
+                            PatternType.SURGE,
+                            Map.of(
+                                    PatternMetric.UPPER_TUKEY_FENCE, upperFence.doubleValue(),
+                                    PatternMetric.MEMPOOL_RECOMMENDED_FEE_PER_VBYTE, mempoolStats.fastFeePerVByte(),
+                                    PatternMetric.MEMPOOL_SIZE, (double) mempoolStats.mempoolSize()
+                            )
+                    ))
                     .build();
         }
         return context;

--- a/src/main/java/com/blockchain/blockpulseservice/service/mapper/AnalyzedTransactionMapper.java
+++ b/src/main/java/com/blockchain/blockpulseservice/service/mapper/AnalyzedTransactionMapper.java
@@ -18,18 +18,22 @@ public class AnalyzedTransactionMapper {
     }
 
     public AnalyzedTransactionEvent map(AnalysisContext context) {
-        return AnalyzedTransactionEvent.builder()
+        var builder = AnalyzedTransactionEvent.builder()
                 .id(context.getNewTransaction().id())
                 .producedAt(Instant.now(clock))
                 .feePerVByte(context.getNewTransaction().feePerVSize())
                 .totalFee(context.getNewTransaction().totalFee())
                 .txSize(context.getNewTransaction().vSize())
                 .timestamp(context.getNewTransaction().time())
-                .patternTypes(context.getPatterns())
                 .priceTier(context.getPriceTier())
                 .isOutlier(context.isOutlier())
-                .windowSnapshot(mapToTransactionWindowSnapshotDTO(context.getFeeWindowStatsSummary()))
-                .build();
+                .windowSnapshot(mapToTransactionWindowSnapshotDTO(context.getFeeWindowStatsSummary()));
+
+        if (context.getPatternSignal() != null) {
+            builder.patternSignal(context.getPatternSignal());
+        }
+
+        return builder.build();
     }
 
     private TransactionWindowSnapshotDTO mapToTransactionWindowSnapshotDTO(FeeWindowStatsSummary windowSnapshot) {

--- a/src/test/java/com/blockchain/blockpulseservice/service/AnalysisStreamTest.java
+++ b/src/test/java/com/blockchain/blockpulseservice/service/AnalysisStreamTest.java
@@ -1,8 +1,10 @@
 package com.blockchain.blockpulseservice.service;
 
 import com.blockchain.blockpulseservice.service.stream.AnalysisStream;
-import com.blockchain.blockpulseservice.model.domain.PatternType;
 import com.blockchain.blockpulseservice.model.domain.PriceTier;
+import com.blockchain.blockpulseservice.model.domain.PatternSignal;
+import com.blockchain.blockpulseservice.model.domain.PatternMetric;
+import com.blockchain.blockpulseservice.model.domain.PatternType;
 import com.blockchain.blockpulseservice.model.dto.TransactionWindowSnapshotDTO;
 import com.blockchain.blockpulseservice.model.event.AnalyzedTransactionEvent;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,9 +12,9 @@ import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
+import java.util.Map;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Set;
 
 class AnalysisStreamTest {
     private static final int REPLAY_LIMIT = 2;
@@ -102,7 +104,7 @@ class AnalysisStreamTest {
                 .totalFee(new BigDecimal("1234"))
                 .txSize(200)
                 .timestamp(Instant.now())
-                .patternTypes(Set.of(PatternType.SURGE))
+                .patternSignal(new PatternSignal(PatternType.SURGE, Map.of(PatternMetric.UPPER_TUKEY_FENCE, 20.0)))
                 .priceTier(PriceTier.NORMAL)
                 .isOutlier(false)
                 .windowSnapshot(new TransactionWindowSnapshotDTO(10, 0, BigDecimal.ZERO, BigDecimal.ZERO))

--- a/src/test/java/com/blockchain/blockpulseservice/service/analysis/SurgeFeeAnalyzerTest.java
+++ b/src/test/java/com/blockchain/blockpulseservice/service/analysis/SurgeFeeAnalyzerTest.java
@@ -3,6 +3,7 @@ package com.blockchain.blockpulseservice.service.analysis;
 import com.blockchain.blockpulseservice.model.domain.AnalysisContext;
 import com.blockchain.blockpulseservice.model.domain.FeeWindowStatsSummary;
 import com.blockchain.blockpulseservice.model.domain.MempoolStats;
+import com.blockchain.blockpulseservice.model.domain.PatternSignal;
 import com.blockchain.blockpulseservice.model.domain.PatternType;
 import com.blockchain.blockpulseservice.model.domain.Transaction;
 import com.google.common.collect.Range;
@@ -13,6 +14,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import com.blockchain.blockpulseservice.model.domain.PatternMetric;
 
 class SurgeFeeAnalyzerTest {
     private static final int MEMPOOL_SIZE_FULL_THRESHOLD = 1000;
@@ -28,10 +30,17 @@ class SurgeFeeAnalyzerTest {
 
         var actualAnalysisContext = analyzer.analyze(ctx);
 
-        assertThat(actualAnalysisContext.getPatterns()).containsExactly(PatternType.SURGE);
+        assertThat(actualAnalysisContext.getPatternSignal())
+                .isNotNull()
+                .extracting(PatternSignal::type)
+                .isEqualTo(PatternType.SURGE);
+        assertThat(actualAnalysisContext.getPatternSignal().metrics())
+                .containsEntry(PatternMetric.UPPER_TUKEY_FENCE, 20.0)
+                .containsEntry(PatternMetric.MEMPOOL_RECOMMENDED_FEE_PER_VBYTE, recommendedFastFee)
+                .containsEntry(PatternMetric.MEMPOOL_SIZE, (double) mempoolSizeCongested);
         assertThat(actualAnalysisContext)
                 .usingRecursiveComparison()
-                .ignoringFields("patterns")
+                .ignoringFields("patternSignal")
                 .isEqualTo(ctx);
     }
 
@@ -44,7 +53,7 @@ class SurgeFeeAnalyzerTest {
 
         var actualAnalysisContext = analyzer.analyze(ctx);
 
-        assertThat(actualAnalysisContext.getPatterns()).isEmpty();
+        assertThat(actualAnalysisContext.getPatternSignal()).isNull();
         assertThat(actualAnalysisContext).isEqualTo(ctx);
     }
 
@@ -57,7 +66,7 @@ class SurgeFeeAnalyzerTest {
 
         var actualAnalysisContext = analyzer.analyze(ctx);
 
-        assertThat(actualAnalysisContext.getPatterns()).isEmpty();
+        assertThat(actualAnalysisContext.getPatternSignal()).isNull();
         assertThat(actualAnalysisContext).isEqualTo(ctx);
     }
 
@@ -70,7 +79,7 @@ class SurgeFeeAnalyzerTest {
 
         var actualAnalysisContext = analyzer.analyze(ctx);
 
-        assertThat(actualAnalysisContext.getPatterns()).isEmpty();
+        assertThat(actualAnalysisContext.getPatternSignal()).isNull();
         assertThat(actualAnalysisContext).isEqualTo(ctx);
     }
 


### PR DESCRIPTION
Adds PatternSignal aggregate and PatternMetric enum, and updates SpamFeeAnalyzer and
SurgeFeeAnalyzer to emit the metric used to detect each pattern. Also extends AnalysisContext and AnalyzedTransactionEvent to carry
patternSignals.

Changes:
- Add PatternSignal {type, metric, metricValue}
- Add PatternMetric enum: UPPER_TUKEY_FENCE_K_1_5,
LOWER_TUKEY_FENCE_K_1_5, MEMPOOL_STATS
- Surge/Spam analyzers emit corresponding PatternSignal
- Mapper includes patternSignals
in event (optional when empty)

Notes:
- We can add additional signals (e.g., MEMPOOL_STATS) for surge heuristics if
desired)

Tests:
- Existing tests should pass; can add targeted assertions for patternSignals if wanted.